### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/geoipdb_updater.sh
+++ b/geoipdb_updater.sh
@@ -6,7 +6,7 @@ echo " "
 echo " "
 download()
 {
-    maxmindURL="http://geolite.maxmind.com/download/geoip/database"
+    maxmindURL="https://geolite.maxmind.com/download/geoip/database"
     libpath="libraries/maxmind"
     MyPath=$(pwd)
  
@@ -60,13 +60,13 @@ download "" $file $newFile
 #------------------------- ASN -------------------------------------------
 file="GeoIPASNum.dat.gz"
 newFile="GeoIPASNum.dat"
-#http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+#https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
 
 download "asnum/" $file $newFile
 #--------------------------------------------------------------------
 file="GeoIPASNumv6.dat.gz"
 newFile="GeoIPASNumv6.dat"
-#http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
+#https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz
 
 download "asnum/" $file $newFile
 #--------------------------------------------------------------------


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).